### PR TITLE
Added QuestLineEntry table.

### DIFF
--- a/src/main/java/com/github/dcysteine/nesql/exporter/plugin/quest/factory/QuestLineEntryFactory.java
+++ b/src/main/java/com/github/dcysteine/nesql/exporter/plugin/quest/factory/QuestLineEntryFactory.java
@@ -1,0 +1,32 @@
+package com.github.dcysteine.nesql.exporter.plugin.quest.factory;
+
+import betterquesting.api.questing.IQuestLineEntry;
+import com.github.dcysteine.nesql.exporter.plugin.EntityFactory;
+import com.github.dcysteine.nesql.exporter.plugin.PluginExporter;
+import com.github.dcysteine.nesql.exporter.util.IdPrefixUtil;
+import com.github.dcysteine.nesql.sql.quest.Quest;
+import com.github.dcysteine.nesql.sql.quest.QuestLine;
+import com.github.dcysteine.nesql.sql.quest.QuestLineEntry;
+
+import java.util.UUID;
+
+public class QuestLineEntryFactory extends EntityFactory<QuestLineEntry, String> {
+    private final QuestFactory questFactory;
+
+    public QuestLineEntryFactory(PluginExporter exporter) {
+        super(exporter);
+        questFactory = new QuestFactory(exporter);
+    }
+
+    public QuestLineEntry get(QuestLine questLine, UUID questId, IQuestLineEntry questLineEntry) {
+        Quest quest = questFactory.findQuest(questId);
+        String id = IdPrefixUtil.QUEST_LINE_ENTRY.applyPrefix(questLine.getId() + "~" + quest.getId());
+        int posX = questLineEntry.getPosX();
+        int posY = questLineEntry.getPosY();
+        int sizeX = questLineEntry.getSizeX();
+        int sizeY = questLineEntry.getSizeY();
+
+        QuestLineEntry questLineEntryEntity = new QuestLineEntry(id, posX, posY, sizeX, sizeY, questLine, quest);
+        return findOrPersist(QuestLineEntry.class, questLineEntryEntity);
+    }
+}

--- a/src/main/java/com/github/dcysteine/nesql/exporter/plugin/quest/factory/QuestLineFactory.java
+++ b/src/main/java/com/github/dcysteine/nesql/exporter/plugin/quest/factory/QuestLineFactory.java
@@ -2,6 +2,7 @@ package com.github.dcysteine.nesql.exporter.plugin.quest.factory;
 
 import betterquesting.api.properties.NativeProps;
 import betterquesting.api.questing.IQuestLine;
+import betterquesting.api.questing.IQuestLineEntry;
 import betterquesting.api.utils.UuidConverter;
 import betterquesting.api2.utils.QuestTranslation;
 import com.github.dcysteine.nesql.exporter.plugin.EntityFactory;
@@ -10,22 +11,22 @@ import com.github.dcysteine.nesql.exporter.plugin.base.factory.ItemFactory;
 import com.github.dcysteine.nesql.exporter.util.IdPrefixUtil;
 import com.github.dcysteine.nesql.exporter.util.StringUtil;
 import com.github.dcysteine.nesql.sql.base.item.Item;
-import com.github.dcysteine.nesql.sql.quest.Quest;
 import com.github.dcysteine.nesql.sql.quest.QuestLine;
+import com.github.dcysteine.nesql.sql.quest.QuestLineEntry;
 
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 public class QuestLineFactory extends EntityFactory<QuestLine, String> {
     private final ItemFactory itemFactory;
-    private final QuestFactory questFactory;
+    private final QuestLineEntryFactory questLineEntryFactory;
 
     public QuestLineFactory(PluginExporter exporter) {
         super(exporter);
         itemFactory = new ItemFactory(exporter);
-        questFactory = new QuestFactory(exporter);
+        questLineEntryFactory = new QuestLineEntryFactory(exporter);
     }
 
     public QuestLine get(UUID questLineId, IQuestLine questLine) {
@@ -41,13 +42,16 @@ public class QuestLineFactory extends EntityFactory<QuestLine, String> {
                         QuestTranslation.translate(questLine.getProperty(NativeProps.DESC)));
         String visibility = questLine.getProperty(NativeProps.VISIBILITY).name();
 
-        Set<Quest> quests =
-                questLine.keySet().stream()
-                        .map(questFactory::findQuest)
-                        .collect(Collectors.toCollection(HashSet::new));
-
+        Set<QuestLineEntry> questLineEntries = new HashSet<>();
         QuestLine questLineEntity =
-                new QuestLine(id, encodedQuestLineId, icon, name, description, visibility, quests);
+                new QuestLine(id, encodedQuestLineId, icon, name, description, visibility, questLineEntries);
+
+        Set<Map.Entry<UUID, IQuestLineEntry>> qlEntries = questLine.entrySet();
+
+        for (Map.Entry<UUID, IQuestLineEntry> entry : qlEntries) {
+            questLineEntries.add(questLineEntryFactory.get(questLineEntity, entry.getKey(), entry.getValue()));
+        }
+
         return findOrPersist(QuestLine.class, questLineEntity);
     }
 }

--- a/src/main/java/com/github/dcysteine/nesql/exporter/util/IdPrefixUtil.java
+++ b/src/main/java/com/github/dcysteine/nesql/exporter/util/IdPrefixUtil.java
@@ -26,6 +26,7 @@ public enum IdPrefixUtil {
 
     QUEST("q"),
     QUEST_LINE("ql"),
+    QUEST_LINE_ENTRY("qle"),
     QUEST_TASK("qt"),
     QUEST_REWARD("qr"),
     ;

--- a/src/main/java/com/github/dcysteine/nesql/sql/quest/Quest.java
+++ b/src/main/java/com/github/dcysteine/nesql/sql/quest/Quest.java
@@ -44,10 +44,10 @@ public class Quest implements Identifiable<String> {
 
     private int repeatTime;
 
-    /** Quest lines that this quest belongs to. */
+    /** Quest line entries that this quest belongs to. */
     @EqualsAndHashCode.Exclude
-    @ManyToMany(mappedBy = "quests")
-    private Set<QuestLine> questLines;
+    @OneToMany(mappedBy = "quest")
+    private Set<QuestLineEntry> questLineEntries;
 
     @Column(nullable = false)
     private String questLogic;
@@ -127,8 +127,8 @@ public class Quest implements Identifiable<String> {
         return repeatTime;
     }
 
-    public Set<QuestLine> getQuestLines() {
-        return questLines;
+    public Set<QuestLineEntry> getQuestLineEntries() {
+        return questLineEntries;
     }
 
     public String getQuestLogic() {

--- a/src/main/java/com/github/dcysteine/nesql/sql/quest/QuestLine.java
+++ b/src/main/java/com/github/dcysteine/nesql/sql/quest/QuestLine.java
@@ -3,11 +3,7 @@ package com.github.dcysteine.nesql.sql.quest;
 import com.github.dcysteine.nesql.sql.Identifiable;
 import com.github.dcysteine.nesql.sql.Metadata;
 import com.github.dcysteine.nesql.sql.base.item.Item;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -38,24 +34,24 @@ public class QuestLine implements Identifiable<String> {
     @Column(nullable = false)
     private String visibility;
 
-    /** Quests that are part of this quest line. */
+    /** Quest line entries that are part of this quest line. */
     @EqualsAndHashCode.Exclude
-    @ManyToMany
-    private Set<Quest> quests;
+    @OneToMany(mappedBy = "questLine")
+    private Set<QuestLineEntry> questLineEntries;
 
     /** Needed by Hibernate. */
     protected QuestLine() {}
 
     public QuestLine(
             String id, String questLineId, Item icon, String name, String description,
-            String visibility, Set<Quest> quests) {
+            String visibility, Set<QuestLineEntry> questLineEntries) {
         this.id = id;
         this.questLineId = questLineId;
         this.icon = icon;
         this.name = name;
         this.description = description;
         this.visibility = visibility;
-        this.quests = quests;
+        this.questLineEntries = questLineEntries;
     }
 
     @Override
@@ -83,8 +79,8 @@ public class QuestLine implements Identifiable<String> {
         return visibility;
     }
 
-    public Set<Quest> getQuests() {
-        return quests;
+    public Set<QuestLineEntry> getQuestLineEntries() {
+        return questLineEntries;
     }
 
     @Override

--- a/src/main/java/com/github/dcysteine/nesql/sql/quest/QuestLineEntry.java
+++ b/src/main/java/com/github/dcysteine/nesql/sql/quest/QuestLineEntry.java
@@ -1,0 +1,93 @@
+package com.github.dcysteine.nesql.sql.quest;
+
+import com.github.dcysteine.nesql.sql.Identifiable;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.Comparator;
+
+/** Holds information about a BetterQuesting quest line entry. */
+@Entity
+@EqualsAndHashCode
+@ToString
+public class QuestLineEntry implements Identifiable<String> {
+    @Id
+    private String id;
+
+    @Column(nullable = false)
+    private int posX;
+
+    @Column(nullable = false)
+    private int posY;
+
+    @Column(nullable = false)
+    private int sizeX;
+
+    @Column(nullable = false)
+    private int sizeY;
+
+    /** Quest line that this quest line entry belongs to. */
+    @EqualsAndHashCode.Exclude
+    @ManyToOne
+    private QuestLine questLine;
+
+    /** Quest that is a part of this quest line entry. */
+    @EqualsAndHashCode.Exclude
+    @ManyToOne
+    private Quest quest;
+
+    /** Needed by Hibernate. */
+    protected QuestLineEntry() {}
+
+    public QuestLineEntry(
+            String id, int posX, int posY, int sizeX, int sizeY, QuestLine questLine, Quest quest) {
+        this.id = id;
+        this.posX = posX;
+        this.posY = posY;
+        this.sizeX = sizeX;
+        this.sizeY = sizeY;
+        this.questLine = questLine;
+        this.quest = quest;
+    }
+
+    @Override
+    public String getId() { return id; }
+
+    public int getPosX() {
+        return posX;
+    }
+
+    public int getPosY() {
+        return posY;
+    }
+
+    public int getSizeX() {
+        return sizeX;
+    }
+
+    public int getSizeY() {
+        return sizeY;
+    }
+
+    public QuestLine getQuestLine() {
+        return questLine;
+    }
+
+    public Quest getQuest() {
+        return quest;
+    }
+
+    @Override
+    public int compareTo(Identifiable<String> other) {
+        if (other instanceof QuestLineEntry) {
+            return Comparator.comparing(QuestLineEntry::getId)
+                    .compare(this, (QuestLineEntry) other);
+        } else {
+            return Identifiable.super.compareTo(other);
+        }
+    }
+}


### PR DESCRIPTION
Added changes needed for QuestLineEntry table.
Results:
- Table definition:
```
CREATE MEMORY TABLE PUBLIC.QUEST_LINE_ENTRY(ID VARCHAR(255) NOT NULL PRIMARY KEY,POSX INTEGER NOT NULL,POSY INTEGER NOT NULL,SIZEX INTEGER NOT NULL,SIZEY INTEGER NOT NULL,QUEST_ID VARCHAR(255),QUEST_LINE_ID VARCHAR(255),CONSTRAINT FKSG9I6X4NO0AG3CWU8MAMXEORG FOREIGN KEY(QUEST_ID) REFERENCES PUBLIC.QUEST(ID),CONSTRAINT FKNCOIUVGOMS4H9TE2YKPROUQP5 FOREIGN KEY(QUEST_LINE_ID) REFERENCES PUBLIC.QUEST_LINE(ID))
```
- Insert example:
```
INSERT INTO QUEST_LINE_ENTRY VALUES('qle~ql~AAAAAAAAAAAAAAAAAAAAAA==~q~AAAAAAAAAAAAAAAAAAAAAA==',12,48,72,72,'q~AAAAAAAAAAAAAAAAAAAAAA==','ql~AAAAAAAAAAAAAAAAAAAAAA==')
```
I hope we will also soon add mob icons so I can use this for complete questbook parsing.